### PR TITLE
Release v0.1.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 # JetBrains IDE files
-.idea
+/.idea
 
 # TypeScript typings
-typings
+/typings
 
 # TGZ files
 *.tgz

--- a/dist/src/BlitzError.js
+++ b/dist/src/BlitzError.js
@@ -1,0 +1,9 @@
+var BlitzError = (function () {
+    function BlitzError(message, extra) {
+        Error.captureStackTrace(this, this.constructor);
+        this.name = this.constructor.name;
+        this.message = message;
+        this.extra = extra;
+    }
+    return BlitzError;
+}());

--- a/dist/src/ContentParser.js
+++ b/dist/src/ContentParser.js
@@ -1,67 +1,50 @@
 "use strict";
 var fs = require('fs');
 var path = require('path');
-var objectAssign = require('object-assign');
 var fm = require('front-matter');
 var Util_1 = require('./Util');
 var ContentParser = (function () {
     function ContentParser() {
     }
     ContentParser.parse = function (content) {
-        var parsedPage = fm(content);
-        var result = parsedPage.attributes;
-        result.content = Util_1.Util.parseMarkdown(parsedPage.body);
+        var result;
+        var parsedFrontMatter = fm(content);
+        if (typeof parsedFrontMatter.attributes === 'string') {
+            result = {
+                title: parsedFrontMatter.attributes,
+            };
+        }
+        else {
+            result = parsedFrontMatter.attributes;
+        }
+        result.content = Util_1.Util.parseMarkdown(parsedFrontMatter.body);
         return result;
     };
     ContentParser.parseFile = function (filePath) {
-        if (!Util_1.Util.pathExists(filePath)) {
-            Util_1.Util.error('Could not access `' + filePath + '`! Are you sure it exists?');
-            return undefined;
-        }
         if (this.fileCache[filePath] === undefined) {
             var fileContents = Util_1.Util.getFileContents(filePath);
-            if (!fileContents) {
-                Util_1.Util.error('Could not load the specified file for parsing!');
-                return undefined;
-            }
             var rawData = ContentParser.parse(fileContents);
-            if (rawData === undefined) {
-                Util_1.Util.error('Could not parse file contents!');
-                return undefined;
-            }
-            this.fileCache[filePath] = objectAssign({}, rawData, { file: path.basename(filePath) });
+            rawData.file = path.basename(filePath);
+            this.fileCache[filePath] = rawData;
         }
         return this.fileCache[filePath];
     };
     ContentParser.parseDirectory = function (directoryPath) {
-        if (!Util_1.Util.pathExists(directoryPath)) {
-            Util_1.Util.error('Could not access `' + path + '`! Are you sure it exists?');
-            return undefined;
-        }
-        var files = fs.readdirSync(directoryPath);
-        var fileCount = files.length;
-        var directoryData = [];
-        for (var i = 0; i < fileCount; i++) {
-            var filePath = path.join(directoryPath, files[i]);
-            var fileStats = void 0;
-            try {
-                fileStats = fs.lstatSync(filePath);
-            }
-            catch (e) {
-                Util_1.Util.error('Could not fetch stats for `' + filePath + '`!');
-                Util_1.Util.stackTrace(e);
-                return undefined;
-            }
-            if (fileStats.isFile()) {
-                var fileData = ContentParser.parseFile(filePath);
-                if (fileData === undefined) {
-                    Util_1.Util.error('Could not parse content of one of the files in `' + directoryPath + '`!');
-                    return undefined;
+        if (this.directoryCache[directoryPath] === undefined) {
+            var files = fs.readdirSync(directoryPath);
+            var fileCount = files.length;
+            var directoryData = [];
+            for (var i = 0; i < fileCount; i++) {
+                var filePath = path.join(directoryPath, files[i]);
+                var fileStats = fs.lstatSync(filePath);
+                if (fileStats.isFile()) {
+                    var fileData = ContentParser.parseFile(filePath);
+                    directoryData.push(fileData);
                 }
-                directoryData.push(fileData);
             }
+            this.directoryCache[directoryPath] = directoryData;
         }
-        return directoryData;
+        return this.directoryCache[directoryPath];
     };
     ContentParser.directoryCache = {};
     ContentParser.fileCache = {};

--- a/dist/src/ContentParser.js
+++ b/dist/src/ContentParser.js
@@ -2,25 +2,16 @@
 var fs = require('fs');
 var path = require('path');
 var objectAssign = require('object-assign');
+var fm = require('front-matter');
 var Util_1 = require('./Util');
 var ContentParser = (function () {
     function ContentParser() {
     }
     ContentParser.parse = function (content) {
-        var components = content.split(/---\r?\n/);
-        var yamlString = components.shift().replace(/^\s+|\s+$/g, '');
-        var markdownString = components.join('---\n');
-        var htmlContent = Util_1.Util.parseMarkdown(markdownString);
-        if (yamlString === '') {
-            return { content: htmlContent };
-        }
-        var yamlObject = Util_1.Util.parseYaml(yamlString);
-        if (yamlObject === undefined) {
-            Util_1.Util.debug('Could not parse YAML extracted from content!');
-            return undefined;
-        }
-        yamlObject.content = htmlContent;
-        return yamlObject;
+        var parsedPage = fm(content);
+        var result = parsedPage.attributes;
+        result.content = Util_1.Util.parseMarkdown(parsedPage.body);
+        return result;
     };
     ContentParser.parseFile = function (filePath) {
         if (!Util_1.Util.pathExists(filePath)) {

--- a/dist/src/Util.js
+++ b/dist/src/Util.js
@@ -78,17 +78,8 @@ var Util = (function () {
         return true;
     };
     Util.getFileContents = function (filePath) {
-        var fileContents;
         Util.debug('Reading contents of `' + filePath + '`...');
-        try {
-            fileContents = fs.readFileSync(filePath, 'utf8');
-        }
-        catch (e) {
-            Util.error('Error reading `' + filePath + '`. Are you sure it exists?');
-            Util.stackTrace(e);
-            return undefined;
-        }
-        return fileContents;
+        return fs.readFileSync(filePath, 'utf8');
     };
     Util.createDirectory = function (directoryPath) {
         try {

--- a/dist/src/Util.js
+++ b/dist/src/Util.js
@@ -26,6 +26,10 @@ var Util = (function () {
     };
     Util.parseYaml = function (yamlString) {
         Util.debug('Parsing  YAML...');
+        yamlString = yamlString.replace(/^\s+|\s+$/g, '');
+        if (yamlString === '') {
+            return {};
+        }
         var parsedYaml;
         try {
             parsedYaml = yaml.safeLoad(yamlString);

--- a/dist/test/ContentParserTest.js
+++ b/dist/test/ContentParserTest.js
@@ -1,4 +1,5 @@
 "use strict";
+var mock = require('mock-fs');
 var chai_1 = require('chai');
 var Util_1 = require('../src/Util');
 var ContentParser_1 = require('../src/ContentParser');
@@ -7,10 +8,17 @@ describe('ContentParser', function () {
         var lfCases = [
             {
                 yaml: 'test: 123',
+                yamlObject: { test: 123 },
+                markdown: '# Testing Heading',
+            },
+            {
+                yaml: 'Hello',
+                yamlObject: { title: 'Hello' },
                 markdown: '# Testing Heading',
             },
             {
                 yaml: 'test: 123\nstring: \'hello\'',
+                yamlObject: { test: 123, string: 'hello' },
                 markdown: '# Testing Heading\n[This is a link](#)',
             },
         ];
@@ -18,7 +26,7 @@ describe('ContentParser', function () {
         it('should correctly parse strings with LF line endings', function () {
             for (var i = 0; i < lfCasesCount; i++) {
                 var lfCase = lfCases[i];
-                var expectedObject = Util_1.Util.parseYaml(lfCase.yaml);
+                var expectedObject = lfCase.yamlObject;
                 expectedObject.content = Util_1.Util.parseMarkdown(lfCase.markdown);
                 var contentString = '---\n' + lfCase.yaml + '\n---\n' + lfCase.markdown;
                 chai_1.assert.deepEqual(ContentParser_1.ContentParser.parse(contentString), expectedObject);
@@ -27,7 +35,7 @@ describe('ContentParser', function () {
         it('should extract correct data from strings with CRLF line endings', function () {
             for (var i = 0; i < lfCasesCount; i++) {
                 var lfCase = lfCases[i];
-                var expectedObject = Util_1.Util.parseYaml(lfCase.yaml.replace('\n', '\r\n'));
+                var expectedObject = lfCase.yamlObject;
                 expectedObject.content = Util_1.Util.parseMarkdown(lfCase.markdown.replace('\n', '\r\n'));
                 var contentString = '---\r\n' + lfCase.yaml + '---\r\n' + lfCase.markdown;
                 chai_1.assert.deepEqual(ContentParser_1.ContentParser.parse(contentString), expectedObject);
@@ -70,6 +78,201 @@ describe('ContentParser', function () {
             };
             chai_1.assert.deepEqual(ContentParser_1.ContentParser.parse(''), expectedObject);
             chai_1.assert.deepEqual(ContentParser_1.ContentParser.parse('---\n---'), expectedObject);
+        });
+        it('should set `title` to the string in the front matter, if front matter is a single string', function () {
+            var expectedObject = {
+                title: 'This is a string.',
+                content: '',
+            };
+            chai_1.assert.deepEqual(ContentParser_1.ContentParser.parse('---\nThis is a string.\n---'), expectedObject);
+        });
+    });
+    describe('#parseFile()', function () {
+        it('should parse the content of a file if it exists and is readable', function () {
+            var data = {
+                fileName: 'content.md',
+                yaml: 'test: 123',
+                yamlObject: { test: 123 },
+                markdown: '# Testing Heading',
+            };
+            var expectedObject = data.yamlObject;
+            expectedObject.file = data.fileName;
+            expectedObject.content = Util_1.Util.parseMarkdown(data.markdown);
+            var mockConfig = {};
+            mockConfig[data.fileName] = mock.file({
+                content: '---\n' + data.yaml + '\n---\n' + data.markdown,
+                mode: 777,
+            });
+            mock(mockConfig);
+            chai_1.assert.deepEqual(ContentParser_1.ContentParser.parseFile(data.fileName), expectedObject);
+            mock.restore();
+        });
+        it('should return file from cache if it is requested more than once', function () {
+            var data = {
+                fileName: 'uncached.md',
+                yaml: 'test: 123',
+                yamlObject: { test: 123 },
+                markdown: '# Testing Heading',
+            };
+            var expectedObject = data.yamlObject;
+            expectedObject.file = data.fileName;
+            expectedObject.content = Util_1.Util.parseMarkdown(data.markdown);
+            var mockConfig = {};
+            mockConfig[data.fileName] = mock.file({
+                content: '---\n' + data.yaml + '\n---\n' + data.markdown,
+                mode: 777,
+            });
+            chai_1.assert.throws(function () { return ContentParser_1.ContentParser.parseFile(data.fileName); }, 'no such file or directory');
+            mock(mockConfig);
+            chai_1.assert.deepEqual(ContentParser_1.ContentParser.parseFile(data.fileName), expectedObject);
+            mock.restore();
+            mockConfig[data.fileName].content = '';
+            mock(mockConfig);
+            chai_1.assert.deepEqual(ContentParser_1.ContentParser.parseFile(data.fileName), expectedObject);
+            mock.restore();
+        });
+        it('should throw an error when the file does not exist', function () {
+            mock({});
+            chai_1.assert.throws(function () { return ContentParser_1.ContentParser.parseFile('non-existent.md'); }, 'no such file or directory');
+            mock.restore();
+        });
+        it('should throw an error when file can not be read', function () {
+            mock({
+                'non-readable.md': mock.file({
+                    content: '',
+                    mode: 0,
+                }),
+            });
+            chai_1.assert.throws(function () { return ContentParser_1.ContentParser.parseFile('non-readable.md'); }, 'permission denied');
+            mock.restore();
+        });
+    });
+    describe('#parseDirectory()', function () {
+        var files = [
+            {
+                fileName: 'directory-1.md',
+                mode: 777,
+                yaml: 'test: 123',
+                yamlObject: { test: 123 },
+                markdown: '# Testing Heading',
+            },
+            {
+                fileName: 'directory-2.md',
+                mode: 777,
+                yaml: 'test: 123',
+                yamlObject: { test: 123 },
+                markdown: '# Testing Heading',
+            },
+        ];
+        it('should parse the content of all files in directory if it exists and is readable', function () {
+            var dirName = 'dir-name';
+            var expectedObject = [];
+            var mockFiles = {};
+            for (var i = 0; i < files.length; i++) {
+                var file = files[i];
+                var processedFile = file.yamlObject;
+                processedFile.file = file.fileName;
+                processedFile.content = Util_1.Util.parseMarkdown(file.markdown);
+                expectedObject.push(processedFile);
+                mockFiles[file.fileName] = mock.file({
+                    content: '---\n' + file.yaml + '\n---\n' + file.markdown,
+                    mode: file.mode,
+                });
+            }
+            var mockConfig = {};
+            mockConfig[dirName] = mock.directory({
+                items: mockFiles,
+            });
+            mock(mockConfig);
+            chai_1.assert.deepEqual(ContentParser_1.ContentParser.parseDirectory('dir-name'), expectedObject);
+            mock.restore();
+        });
+        it('should return directory contents from cache if it is requested more than once', function () {
+            var dirName = 'uncached-dir';
+            var expectedObject = [];
+            var mockFiles = {};
+            for (var i = 0; i < files.length; i++) {
+                var file = files[i];
+                var processedFile = file.yamlObject;
+                processedFile.file = file.fileName;
+                processedFile.content = Util_1.Util.parseMarkdown(file.markdown);
+                expectedObject.push(processedFile);
+                mockFiles[file.fileName] = mock.file({
+                    content: '---\n' + file.yaml + '\n---\n' + file.markdown,
+                    mode: file.mode,
+                });
+            }
+            var mockConfig = {};
+            mockConfig[dirName] = mock.directory({
+                items: mockFiles,
+            });
+            chai_1.assert.throws(function () { return ContentParser_1.ContentParser.parseDirectory(dirName); }, 'no such file or directory');
+            mock(mockConfig);
+            chai_1.assert.deepEqual(ContentParser_1.ContentParser.parseDirectory(dirName), expectedObject);
+            mock.restore();
+            mockConfig[dirName] = {};
+            mock(mockConfig);
+            chai_1.assert.deepEqual(ContentParser_1.ContentParser.parseDirectory(dirName), expectedObject);
+            mock.restore();
+        });
+        it('should throw an error when the directory does not exist', function () {
+            mock({});
+            chai_1.assert.throws(function () { return ContentParser_1.ContentParser.parseDirectory('non-existent'); }, 'no such file or directory');
+            mock.restore();
+        });
+        it('should throw an error when directory is not empty and not be readable', function () {
+            var dirName = 'dir-with-unreadable';
+            var expectedObject = [];
+            var mockFiles = {};
+            for (var i = 0; i < files.length; i++) {
+                var file = files[i];
+                var processedFile = file.yamlObject;
+                processedFile.file = file.fileName;
+                processedFile.content = Util_1.Util.parseMarkdown(file.markdown);
+                expectedObject.push(processedFile);
+                mockFiles[file.fileName] = mock.file({
+                    content: '---\n' + file.yaml + '\n---\n' + file.markdown,
+                    mode: file.mode,
+                });
+            }
+            var mockConfig = {};
+            mockConfig[dirName] = mock.directory({
+                mode: 0,
+                items: mockFiles,
+            });
+            mock(mockConfig);
+            chai_1.assert.throws(function () { return ContentParser_1.ContentParser.parseDirectory(dirName); }, 'permission denied');
+            mock.restore();
+        });
+        it('should throw an error when one of the file in directory can not be read', function () {
+            files.push({
+                fileName: 'not-readable.md',
+                mode: 0,
+                yaml: 'test: 123',
+                yamlObject: { test: 123 },
+                markdown: '# Testing Heading',
+            });
+            var dirName = 'dir-with-unreadable';
+            var expectedObject = [];
+            var mockFiles = {};
+            for (var i = 0; i < files.length; i++) {
+                var file = files[i];
+                var processedFile = file.yamlObject;
+                processedFile.file = file.fileName;
+                processedFile.content = Util_1.Util.parseMarkdown(file.markdown);
+                expectedObject.push(processedFile);
+                mockFiles[file.fileName] = mock.file({
+                    content: '---\n' + file.yaml + '\n---\n' + file.markdown,
+                    mode: file.mode,
+                });
+            }
+            var mockConfig = {};
+            mockConfig[dirName] = mock.directory({
+                items: mockFiles,
+            });
+            mock(mockConfig);
+            chai_1.assert.throws(function () { return ContentParser_1.ContentParser.parseDirectory(dirName); }, 'permission denied');
+            mock.restore();
         });
     });
 });

--- a/dist/test/ContentParserTest.js
+++ b/dist/test/ContentParserTest.js
@@ -4,26 +4,72 @@ var Util_1 = require('../src/Util');
 var ContentParser_1 = require('../src/ContentParser');
 describe('ContentParser', function () {
     describe('#parse()', function () {
-        var LF = 'test: 123\n---\n# MARKDOWN!';
-        var CRLF = 'test: 123\r\n---\r\n# MARKDOWN!';
-        var lineEndingsObject = {
-            test: 123,
-            content: Util_1.Util.parseMarkdown('# MARKDOWN!'),
-        };
-        it('should extract correct data from files with LF line endings', function () {
-            chai_1.assert.deepEqual(ContentParser_1.ContentParser.parse(LF), lineEndingsObject);
+        var lfCases = [
+            {
+                yaml: 'test: 123',
+                markdown: '# Testing Heading',
+            },
+            {
+                yaml: 'test: 123\nstring: \'hello\'',
+                markdown: '# Testing Heading\n[This is a link](#)',
+            },
+        ];
+        var lfCasesCount = lfCases.length;
+        it('should correctly parse strings with LF line endings', function () {
+            for (var i = 0; i < lfCasesCount; i++) {
+                var lfCase = lfCases[i];
+                var expectedObject = Util_1.Util.parseYaml(lfCase.yaml);
+                expectedObject.content = Util_1.Util.parseMarkdown(lfCase.markdown);
+                var contentString = '---\n' + lfCase.yaml + '\n---\n' + lfCase.markdown;
+                chai_1.assert.deepEqual(ContentParser_1.ContentParser.parse(contentString), expectedObject);
+            }
         });
-        it('should extract correct data from files with CRLF line endings', function () {
-            chai_1.assert.deepEqual(ContentParser_1.ContentParser.parse(CRLF), lineEndingsObject);
+        it('should extract correct data from strings with CRLF line endings', function () {
+            for (var i = 0; i < lfCasesCount; i++) {
+                var lfCase = lfCases[i];
+                var expectedObject = Util_1.Util.parseYaml(lfCase.yaml.replace('\n', '\r\n'));
+                expectedObject.content = Util_1.Util.parseMarkdown(lfCase.markdown.replace('\n', '\r\n'));
+                var contentString = '---\r\n' + lfCase.yaml + '---\r\n' + lfCase.markdown;
+                chai_1.assert.deepEqual(ContentParser_1.ContentParser.parse(contentString), expectedObject);
+            }
         });
-        var markdownOnly = '---\n# MARKDOWN!';
-        var markdownOnlyNewLine = '\n---\n# MARKDOWN!';
-        var onlyMarkdownObject = {
-            content: Util_1.Util.parseMarkdown('# MARKDOWN!'),
-        };
-        it('should extract markdown correctly from a file with no YAML', function () {
-            chai_1.assert.deepEqual(ContentParser_1.ContentParser.parse(markdownOnly), onlyMarkdownObject);
-            chai_1.assert.deepEqual(ContentParser_1.ContentParser.parse(markdownOnlyNewLine), onlyMarkdownObject);
+        var markdownOnlyCases = [
+            '# Hello Word\n> This is a quote',
+            '\n\n\n\njust text',
+            '[This is a link](#) followed by some **bold text**',
+            '\n\n\n\n\n\n',
+            '',
+        ];
+        var markdownOnlyCasesCount = markdownOnlyCases.length;
+        it('should save parsed Markdown into `content` when there is no YAML', function () {
+            for (var i = 0; i < markdownOnlyCasesCount; i++) {
+                var onlyCase = markdownOnlyCases[i];
+                var expectedObject = {
+                    content: Util_1.Util.parseMarkdown(onlyCase),
+                };
+                chai_1.assert.deepEqual(ContentParser_1.ContentParser.parse(onlyCase), expectedObject);
+            }
+        });
+        var yamlOnlyCases = [
+            'hello: 123',
+            '\n',
+            'test: \'string\'\nhello: 321',
+        ];
+        var yamlOnlyCaseCount = yamlOnlyCases.length;
+        it('should parse YAML correctly when there is no Markdown', function () {
+            for (var i = 0; i < yamlOnlyCaseCount; i++) {
+                var onlyCase = yamlOnlyCases[i];
+                var expectedObject = Util_1.Util.parseYaml(onlyCase);
+                expectedObject.content = '';
+                chai_1.assert.deepEqual(ContentParser_1.ContentParser.parse('---\n' + onlyCase + '\n---'), expectedObject);
+            }
+        });
+        it('should return an object with an empty `content` property for empty strings and `---`', function () {
+            var expectedObject = {
+                content: '',
+            };
+            chai_1.assert.deepEqual(ContentParser_1.ContentParser.parse(''), expectedObject);
+            chai_1.assert.deepEqual(ContentParser_1.ContentParser.parse('---\n---'), expectedObject);
         });
     });
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,7 +3,8 @@
  * @author Timur Kuzhagaliyev <tim.kuzh@gmail.com>
  * @copyright 2016
  * @license GPL-3.0
- * @version 0.0.1
+ * @since 0.1.2 Change test directory from `tests` to `test`
+ * @since 0.0.1
  */
 
 var gulp = require('gulp');
@@ -18,5 +19,5 @@ gulp.task('ts', function() {
 
 gulp.task('watch', ['ts'], function() {
     gulp.watch('src/*.ts', ['ts']);
-    gulp.watch('tests/*.ts', ['ts']);
+    gulp.watch('test/*.ts', ['ts']);
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blitz-ssg",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Dead simple static site generator using Markdown and Pug (formerly Jade).",
   "preferGlobal": true,
   "bin": {
@@ -36,10 +36,12 @@
     "gulp": "^3.9.1",
     "gulp-typescript": "^3.1.2",
     "mocha": "^3.1.2",
+    "mock-fs": "^3.12.1",
     "typescript": "^2.0.9"
   },
   "dependencies": {
     "colors": "^1.1.2",
+    "front-matter": "^2.1.0",
     "fs-extra": "^1.0.0",
     "js-yaml": "^3.6.1",
     "marked": "^0.3.6",

--- a/src/SiteBuilder.ts
+++ b/src/SiteBuilder.ts
@@ -106,7 +106,7 @@ interface IBlitzProcessedPageURLs {
 interface IBlitzProcessedPage {
     url: (currentDirectoryArray?: string[]) => string;
     content: string;
-    [key: string]: string;
+    [key: string]: string|((currentDirectoryArray?: string[]) => string);
 }
 
 /**

--- a/src/SiteBuilder.ts
+++ b/src/SiteBuilder.ts
@@ -101,12 +101,14 @@ interface IBlitzProcessedPageURLs {
 
 /**
  * Page content data with inserted URL
+ * @since 0.1.2 Added `file`, changed type of values from `string` to `any`
  * @since 0.0.1
  */
 interface IBlitzProcessedPage {
     url: (currentDirectoryArray?: string[]) => string;
+    file: string;
     content: string;
-    [key: string]: string|((currentDirectoryArray?: string[]) => string);
+    [key: string]: any;
 }
 
 /**

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -61,6 +61,7 @@ export class Util {
 
     /**
      * Produces an object from YAML string if possible, returns undefined otherwise.
+     * @deprecated
      * @since 0.1.2 Returns empty object for files that only have whitespace
      * @since 0.0.1
      */
@@ -134,19 +135,12 @@ export class Util {
 
     /**
      * Loads file from the specified path if possible, returns undefined otherwise
+     * @since 0.1.2 Removed try/catch block
      * @since 0.0.1
      */
     public static getFileContents(filePath: string): string {
-        let fileContents: string;
         Util.debug('Reading contents of `' + filePath + '`...');
-        try {
-            fileContents = fs.readFileSync(filePath, 'utf8');
-        } catch (e) {
-            Util.error('Error reading `' + filePath + '`. Are you sure it exists?');
-            Util.stackTrace(e);
-            return undefined;
-        }
-        return fileContents;
+        return fs.readFileSync(filePath, 'utf8');
     }
 
     /**
@@ -237,4 +231,3 @@ export class Util {
         return result;
     }
 }
-

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -61,10 +61,15 @@ export class Util {
 
     /**
      * Produces an object from YAML string if possible, returns undefined otherwise.
+     * @since 0.1.2 Returns empty object for files that only have whitespace
      * @since 0.0.1
      */
     public static parseYaml(yamlString: string): any {
         Util.debug('Parsing  YAML...');
+        yamlString = yamlString.replace(/^\s+|\s+$/g, '');
+        if (yamlString === '') {
+            return {};
+        }
         let parsedYaml: any;
         try {
             parsedYaml = yaml.safeLoad(yamlString);

--- a/src/node.d.ts
+++ b/src/node.d.ts
@@ -1,8 +1,0 @@
-/**
- * Declaring debug global variable
- */
-declare namespace NodeJS  {
-    interface Global {
-        debug: boolean;
-    }
-}

--- a/src/typings/front-matter.d.ts
+++ b/src/typings/front-matter.d.ts
@@ -1,0 +1,5 @@
+declare module 'front-matter' {
+    function fm(fmString: string): { attributes: any; body: string; frontmatter: string; };
+    namespace fm {}
+    export = fm;
+}

--- a/src/typings/node.d.ts
+++ b/src/typings/node.d.ts
@@ -1,0 +1,9 @@
+/**
+ * Various declarations missing from Node.js, needed to fix TypeScript compiler errors
+ * @since 0.0.1
+ */
+declare namespace NodeJS  {
+    interface Global {
+        debug: boolean;
+    }
+}

--- a/templates/minimal/blitz.yml
+++ b/templates/minimal/blitz.yml
@@ -10,7 +10,7 @@
 
 # Version of Blitz used to generate this project. Used for
 # migration purposes.
-blitz_version: '0.1.1'
+blitz_version: '0.1.2'
 
 # Site URL without a trailing slash. This is not used in URL
 # generation but is rather available for your own convenience.

--- a/templates/minimal/content/index.md
+++ b/templates/minimal/content/index.md
@@ -1,3 +1,4 @@
+---
 title: 'Minimal Blitz Template'
 ---
 # Welcome!

--- a/test/ContentParserTest.ts
+++ b/test/ContentParserTest.ts
@@ -9,30 +9,84 @@
 import {assert} from 'chai';
 import {Util} from '../src/Util';
 import {ContentParser} from '../src/ContentParser';
+import * as mock from 'mock-fs';
 
 describe('ContentParser', () => {
     describe('#parse()', () => {
-        let LF = 'test: 123\n---\n# MARKDOWN!';
-        let CRLF = 'test: 123\r\n---\r\n# MARKDOWN!';
-        let lineEndingsObject = {
-            test: 123,
-            content: Util.parseMarkdown('# MARKDOWN!'),
-        };
-        it('should extract correct data from files with LF line endings', () => {
-            assert.deepEqual(ContentParser.parse(LF), lineEndingsObject);
+
+        interface ILFCase {
+            yaml: string;
+            markdown: string;
+        }
+        let lfCases: ILFCase[] = [
+            {
+                yaml: 'test: 123',
+                markdown: '# Testing Heading',
+            },
+            {
+                yaml: 'test: 123\nstring: \'hello\'',
+                markdown: '# Testing Heading\n[This is a link](#)',
+            },
+        ];
+        let lfCasesCount = lfCases.length;
+        it('should correctly parse strings with LF line endings', () => {
+            for (let i = 0; i < lfCasesCount; i++) {
+                let lfCase = lfCases[i];
+                let expectedObject = Util.parseYaml(lfCase.yaml);
+                expectedObject.content = Util.parseMarkdown(lfCase.markdown);
+                let contentString = '---\n' + lfCase.yaml + '\n---\n' + lfCase.markdown;
+                assert.deepEqual(ContentParser.parse(contentString), expectedObject);
+            }
         });
-        it('should extract correct data from files with CRLF line endings', () => {
-            assert.deepEqual(ContentParser.parse(CRLF), lineEndingsObject);
+        it('should extract correct data from strings with CRLF line endings', () => {
+            for (let i = 0; i < lfCasesCount; i++) {
+                let lfCase = lfCases[i];
+                let expectedObject = Util.parseYaml(lfCase.yaml.replace('\n', '\r\n'));
+                expectedObject.content = Util.parseMarkdown(lfCase.markdown.replace('\n', '\r\n'));
+                let contentString = '---\r\n' + lfCase.yaml + '---\r\n' + lfCase.markdown;
+                assert.deepEqual(ContentParser.parse(contentString), expectedObject);
+            }
         });
 
-        let markdownOnly = '---\n# MARKDOWN!';
-        let markdownOnlyNewLine = '\n---\n# MARKDOWN!';
-        let onlyMarkdownObject = {
-            content: Util.parseMarkdown('# MARKDOWN!'),
-        };
-        it('should extract markdown correctly from a file with no YAML', () => {
-            assert.deepEqual(ContentParser.parse(markdownOnly), onlyMarkdownObject);
-            assert.deepEqual(ContentParser.parse(markdownOnlyNewLine), onlyMarkdownObject);
+        let markdownOnlyCases = [
+            '# Hello Word\n> This is a quote',
+            '\n\n\n\njust text',
+            '[This is a link](#) followed by some **bold text**',
+            '\n\n\n\n\n\n',
+            '',
+        ];
+        let markdownOnlyCasesCount = markdownOnlyCases.length;
+        it('should save parsed Markdown into `content` when there is no YAML', () => {
+            for (let i = 0; i < markdownOnlyCasesCount; i++) {
+                let onlyCase = markdownOnlyCases[i];
+                let expectedObject = {
+                    content: Util.parseMarkdown(onlyCase),
+                };
+                assert.deepEqual(ContentParser.parse(onlyCase), expectedObject);
+            }
+        });
+
+        let yamlOnlyCases = [
+            'hello: 123',
+            '\n',
+            'test: \'string\'\nhello: 321',
+        ];
+        let yamlOnlyCaseCount = yamlOnlyCases.length;
+        it('should parse YAML correctly when there is no Markdown', () => {
+            for (let i = 0; i < yamlOnlyCaseCount; i++) {
+                let onlyCase = yamlOnlyCases[i];
+                let expectedObject = Util.parseYaml(onlyCase);
+                expectedObject.content = '';
+                assert.deepEqual(ContentParser.parse('---\n' + onlyCase + '\n---'), expectedObject);
+            }
+        });
+
+        it('should return an object with an empty `content` property for empty strings and `---`', () => {
+            let expectedObject = {
+                content: '',
+            };
+            assert.deepEqual(ContentParser.parse(''), expectedObject);
+            assert.deepEqual(ContentParser.parse('---\n---'), expectedObject);
         });
     });
 });

--- a/test/ContentParserTest.ts
+++ b/test/ContentParserTest.ts
@@ -6,25 +6,34 @@
  * @since 0.0.1
  */
 
+import * as mock from 'mock-fs';
 import {assert} from 'chai';
 import {Util} from '../src/Util';
 import {ContentParser} from '../src/ContentParser';
-import * as mock from 'mock-fs';
 
 describe('ContentParser', () => {
+
     describe('#parse()', () => {
 
         interface ILFCase {
             yaml: string;
+            yamlObject: any;
             markdown: string;
         }
         let lfCases: ILFCase[] = [
             {
                 yaml: 'test: 123',
+                yamlObject: {test: 123},
+                markdown: '# Testing Heading',
+            },
+            {
+                yaml: 'Hello',
+                yamlObject: {title: 'Hello'},
                 markdown: '# Testing Heading',
             },
             {
                 yaml: 'test: 123\nstring: \'hello\'',
+                yamlObject: {test: 123, string: 'hello'},
                 markdown: '# Testing Heading\n[This is a link](#)',
             },
         ];
@@ -32,7 +41,7 @@ describe('ContentParser', () => {
         it('should correctly parse strings with LF line endings', () => {
             for (let i = 0; i < lfCasesCount; i++) {
                 let lfCase = lfCases[i];
-                let expectedObject = Util.parseYaml(lfCase.yaml);
+                let expectedObject = lfCase.yamlObject;
                 expectedObject.content = Util.parseMarkdown(lfCase.markdown);
                 let contentString = '---\n' + lfCase.yaml + '\n---\n' + lfCase.markdown;
                 assert.deepEqual(ContentParser.parse(contentString), expectedObject);
@@ -41,7 +50,7 @@ describe('ContentParser', () => {
         it('should extract correct data from strings with CRLF line endings', () => {
             for (let i = 0; i < lfCasesCount; i++) {
                 let lfCase = lfCases[i];
-                let expectedObject = Util.parseYaml(lfCase.yaml.replace('\n', '\r\n'));
+                let expectedObject = lfCase.yamlObject;
                 expectedObject.content = Util.parseMarkdown(lfCase.markdown.replace('\n', '\r\n'));
                 let contentString = '---\r\n' + lfCase.yaml + '---\r\n' + lfCase.markdown;
                 assert.deepEqual(ContentParser.parse(contentString), expectedObject);
@@ -88,5 +97,221 @@ describe('ContentParser', () => {
             assert.deepEqual(ContentParser.parse(''), expectedObject);
             assert.deepEqual(ContentParser.parse('---\n---'), expectedObject);
         });
+
+        it('should set `title` to the string in the front matter, if front matter is a single string', () => {
+            let expectedObject = {
+                title: 'This is a string.',
+                content: '',
+            };
+            assert.deepEqual(ContentParser.parse('---\nThis is a string.\n---'), expectedObject);
+        });
+
     });
+
+    describe('#parseFile()', () => {
+
+        it('should parse the content of a file if it exists and is readable', () => {
+            let data = {
+                fileName: 'content.md',
+                yaml: 'test: 123',
+                yamlObject: {test: 123},
+                markdown: '# Testing Heading',
+            };
+            let expectedObject: any = data.yamlObject;
+            expectedObject.file = data.fileName;
+            expectedObject.content = Util.parseMarkdown(data.markdown);
+            let mockConfig = {};
+            mockConfig[data.fileName] = mock.file({
+                content: '---\n' + data.yaml + '\n---\n' + data.markdown,
+                mode: 777,
+            });
+            mock(mockConfig);
+            assert.deepEqual(ContentParser.parseFile(data.fileName), expectedObject);
+            mock.restore();
+        });
+
+        it('should return file from cache if it is requested more than once', () => {
+            let data = {
+                fileName: 'uncached.md',
+                yaml: 'test: 123',
+                yamlObject: {test: 123},
+                markdown: '# Testing Heading',
+            };
+            let expectedObject: any = data.yamlObject;
+            expectedObject.file = data.fileName;
+            expectedObject.content = Util.parseMarkdown(data.markdown);
+            let mockConfig = {};
+            mockConfig[data.fileName] = mock.file({
+                content: '---\n' + data.yaml + '\n---\n' + data.markdown,
+                mode: 777,
+            });
+            // Confirm that file has not been cached before
+            assert.throws(() => ContentParser.parseFile(data.fileName), 'no such file or directory');
+            mock(mockConfig);
+            assert.deepEqual(ContentParser.parseFile(data.fileName), expectedObject);
+            mock.restore();
+            // Empty the contents of the file, if cache works return value will be same as above
+            mockConfig[data.fileName].content = '';
+            mock(mockConfig);
+            assert.deepEqual(ContentParser.parseFile(data.fileName), expectedObject);
+            mock.restore();
+        });
+
+        it('should throw an error when the file does not exist', () => {
+            mock({});
+            assert.throws(() => ContentParser.parseFile('non-existent.md'), 'no such file or directory');
+            mock.restore();
+        });
+
+        it('should throw an error when file can not be read', () => {
+            mock({
+                'non-readable.md': mock.file({
+                    content: '',
+                    mode: 0,
+                }),
+            });
+            assert.throws(() => ContentParser.parseFile('non-readable.md'), 'permission denied');
+            mock.restore();
+        });
+
+    });
+
+    describe('#parseDirectory()', () => {
+
+        let files = [
+            {
+                fileName: 'directory-1.md',
+                mode: 777,
+                yaml: 'test: 123',
+                yamlObject: {test: 123},
+                markdown: '# Testing Heading',
+            },
+            {
+                fileName: 'directory-2.md',
+                mode: 777,
+                yaml: 'test: 123',
+                yamlObject: {test: 123},
+                markdown: '# Testing Heading',
+            },
+        ];
+
+        it('should parse the content of all files in directory if it exists and is readable', () => {
+            let dirName = 'dir-name';
+            let expectedObject = [];
+            let mockFiles = {};
+            for (let i = 0; i < files.length; i++) {
+                let file = files[i];
+                let processedFile: any = file.yamlObject;
+                processedFile.file = file.fileName;
+                processedFile.content = Util.parseMarkdown(file.markdown);
+                expectedObject.push(processedFile);
+                mockFiles[file.fileName] = mock.file({
+                    content: '---\n' + file.yaml + '\n---\n' + file.markdown,
+                    mode: file.mode,
+                });
+            }
+            let mockConfig = {};
+            mockConfig[dirName] = mock.directory({
+                items: mockFiles,
+            });
+            mock(mockConfig);
+            assert.deepEqual(ContentParser.parseDirectory('dir-name'), expectedObject);
+            mock.restore();
+        });
+
+        it('should return directory contents from cache if it is requested more than once', () => {
+            let dirName = 'uncached-dir';
+            let expectedObject = [];
+            let mockFiles = {};
+            for (let i = 0; i < files.length; i++) {
+                let file = files[i];
+                let processedFile: any = file.yamlObject;
+                processedFile.file = file.fileName;
+                processedFile.content = Util.parseMarkdown(file.markdown);
+                expectedObject.push(processedFile);
+                mockFiles[file.fileName] = mock.file({
+                    content: '---\n' + file.yaml + '\n---\n' + file.markdown,
+                    mode: file.mode,
+                });
+            }
+            let mockConfig = {};
+            mockConfig[dirName] = mock.directory({
+                items: mockFiles,
+            });
+            // Confirm that directory has not been cached before
+            assert.throws(() => ContentParser.parseDirectory(dirName), 'no such file or directory');
+            mock(mockConfig);
+            assert.deepEqual(ContentParser.parseDirectory(dirName), expectedObject);
+            mock.restore();
+            // Empty the contents of the directory, if cache works return value will be same as above
+            mockConfig[dirName] = {};
+            mock(mockConfig);
+            assert.deepEqual(ContentParser.parseDirectory(dirName), expectedObject);
+            mock.restore();
+        });
+
+        it('should throw an error when the directory does not exist', () => {
+            mock({});
+            assert.throws(() => ContentParser.parseDirectory('non-existent'), 'no such file or directory');
+            mock.restore();
+        });
+
+        it('should throw an error when directory is not empty and not be readable', () => {
+            let dirName = 'dir-with-unreadable';
+            let expectedObject = [];
+            let mockFiles = {};
+            for (let i = 0; i < files.length; i++) {
+                let file = files[i];
+                let processedFile: any = file.yamlObject;
+                processedFile.file = file.fileName;
+                processedFile.content = Util.parseMarkdown(file.markdown);
+                expectedObject.push(processedFile);
+                mockFiles[file.fileName] = mock.file({
+                    content: '---\n' + file.yaml + '\n---\n' + file.markdown,
+                    mode: file.mode,
+                });
+            }
+            let mockConfig = {};
+            mockConfig[dirName] = mock.directory({
+                mode: 0,
+                items: mockFiles,
+            });
+            mock(mockConfig);
+            assert.throws(() => ContentParser.parseDirectory(dirName), 'permission denied');
+            mock.restore();
+        });
+
+        it('should throw an error when one of the file in directory can not be read', () => {
+            files.push({
+                fileName: 'not-readable.md',
+                mode: 0,
+                yaml: 'test: 123',
+                yamlObject: {test: 123},
+                markdown: '# Testing Heading',
+            });
+            let dirName = 'dir-with-unreadable';
+            let expectedObject = [];
+            let mockFiles = {};
+            for (let i = 0; i < files.length; i++) {
+                let file = files[i];
+                let processedFile: any = file.yamlObject;
+                processedFile.file = file.fileName;
+                processedFile.content = Util.parseMarkdown(file.markdown);
+                expectedObject.push(processedFile);
+                mockFiles[file.fileName] = mock.file({
+                    content: '---\n' + file.yaml + '\n---\n' + file.markdown,
+                    mode: file.mode,
+                });
+            }
+            let mockConfig = {};
+            mockConfig[dirName] = mock.directory({
+                items: mockFiles,
+            });
+            mock(mockConfig);
+            assert.throws(() => ContentParser.parseDirectory(dirName), 'permission denied');
+            mock.restore();
+        });
+
+    });
+
 });

--- a/typings.json
+++ b/typings.json
@@ -6,6 +6,7 @@
     "js-yaml": "registry:dt/js-yaml#3.5.2+20160316171810",
     "marked": "registry:dt/marked#0.0.0+20160325085301",
     "mocha": "registry:dt/mocha#2.2.5+20161028141524",
+    "mock-fs": "registry:dt/mock-fs#3.6.0+20160317120654",
     "node": "registry:dt/node#6.0.0+20161110151007",
     "nomnom": "registry:dt/nomnom#0.0.0+20160317120654",
     "object-assign": "registry:dt/object-assign#4.0.1+20161006140353",


### PR DESCRIPTION
* Begun using [front-matter](https://github.com/jxson/front-matter) package to extract front matter from files. As a consequence, the structure of Blitz content files has switched from:
    ```
    <yaml>
    ---
    <markdown>
    ```
    To:
    ```
    ---
    <yaml>
    ---
    <markdown>
    ```
* Begun adding unit tests.