### PR TITLE
Release v0.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Blitz is a dead simple yet powerful static site generator using Node.js, Pug and bits of YAML here and there.
 
 Documentation can be found on [Blitz's website](https://getblitz.io/). You might also be interested in the
-[quick start guide.](https://getblitz.io/docs/0.1/getting-started-template/).
+[quick start guide](https://getblitz.io/docs/0.1/getting-started-template/).
 
 ## Super quick start
 
@@ -33,7 +33,7 @@ Build the static site using Blitz:
 blitz build
 ```
 
-And you're done! Open `index.html` from the newly generated `build` directory in your favourite browsers to view the
+And you're done! Open `index.html` from the newly generated `build` directory in your favourite browser to view the
 website you've just generated.
 
 As the name implies, the minimal template only shows off the basic features of Blitz. To find out more about it, head to
@@ -41,8 +41,8 @@ As the name implies, the minimal template only shows off the basic features of B
 
 ## Developers
 
-This repository is only used for development of the actual Blitz program, it was not meant to be cloned if you're
-planning to use Blitz for static site generation. For that, either use the `Super quick start` section on this page or 
-refer to the *quick start guide* links above.
+This repository contains the source code of Blitz app, do **not** clone it if you want to use Blitz as opposed to
+helping developing it. For an example website built using Blitz, consider [the source code](https://github.com/TimboKZ/blitz-website)
+of Blitz's official website.
 
 I suggest you make use of `tslint.json` provided in this repository to ensure consistent coding style.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![npm version](https://badge.fury.io/js/blitz-ssg.svg)](https://badge.fury.io/js/blitz-ssg)
 [![npm](https://img.shields.io/npm/dm/blitz-ssg.svg)](https://www.npmjs.com/package/blitz-ssg)
+[![David](https://img.shields.io/david/TimboKZ/blitz.svg)](https://www.npmjs.com/package/blitz-ssg)
 [![Build Status](https://travis-ci.org/TimboKZ/blitz.svg?branch=master)](https://travis-ci.org/TimboKZ/blitz)
 [![Coverage Status](https://coveralls.io/repos/github/TimboKZ/blitz/badge.svg?branch=development)](https://coveralls.io/github/TimboKZ/blitz?branch=development)
 

--- a/dist/src/ConfigParser.js
+++ b/dist/src/ConfigParser.js
@@ -41,15 +41,15 @@ exports.CONFIG_PROPERTIES = [
         name: 'globals',
         message: 'Assuming there are no globals',
         defaultValue: {},
-        typeChecker: function (object) { return true; },
-        typeError: '',
+        typeChecker: function (object) { return typeof object === 'object' && !(object instanceof Array); },
+        typeError: 'Globals must be an object (and not an array)!',
     },
     {
         name: 'pages',
         message: 'Assuming there are no pages',
         defaultValue: {},
-        typeChecker: function (object) { return true; },
-        typeError: '',
+        typeChecker: function (object) { return typeof object === 'object' && !(object instanceof Array); },
+        typeError: 'Pages must be an object (and not an array)!',
     },
 ];
 var ConfigParser = (function () {
@@ -81,13 +81,12 @@ var ConfigParser = (function () {
                 config[expected.name] = expected.defaultValue;
             }
             else if (!expected.typeChecker(property)) {
-                var errorString = 'Invalid `' + expected.name + (_a = [""], _a.raw = [""], (' type: ')(_a)) + expected.typeError;
+                var errorString = 'Invalid type for `' + expected.name + '`: ' + expected.typeError;
                 throw new Error(errorString);
             }
         }
         Util_1.Util.debug('Successfully validated Blitz config!');
         return config;
-        var _a;
     };
     return ConfigParser;
 }());

--- a/dist/src/ConfigParser.js
+++ b/dist/src/ConfigParser.js
@@ -1,28 +1,93 @@
 "use strict";
-var path = require('path');
 var Util_1 = require('./Util');
 exports.DEFAULT_CONFIG_NAME = 'blitz.yml';
+exports.CONFIG_PROPERTIES = [
+    {
+        name: 'blitz_version',
+        message: 'Using current Blitz version',
+        defaultValue: Util_1.Util.getPackageInfo().version,
+        typeChecker: function (object) { return typeof object === 'string'; },
+        typeError: 'Blitz version is supposed to be a string!',
+    },
+    {
+        name: 'site_url',
+        message: 'Using an empty string',
+        defaultValue: '',
+        typeChecker: function (object) { return typeof object === 'string'; },
+        typeError: 'Site URL is supposed to be a string!',
+    },
+    {
+        name: 'site_root',
+        message: 'Using an empty string',
+        defaultValue: '',
+        typeChecker: function (object) { return typeof object === 'string'; },
+        typeError: 'Site root is supposed to be a string!',
+    },
+    {
+        name: 'absolute_urls',
+        message: 'Disabling absolute URLs, using relative URLs instead',
+        defaultValue: false,
+        typeChecker: function (object) { return typeof object === 'boolean'; },
+        typeError: 'Absolute URLs should be a boolean value!',
+    },
+    {
+        name: 'explicit_html_extensions',
+        message: 'Enabling explicit HTML extensions',
+        defaultValue: true,
+        typeChecker: function (object) { return typeof object === 'boolean'; },
+        typeError: 'Explicit HTML extensions should be a boolean value!',
+    },
+    {
+        name: 'globals',
+        message: 'Assuming there are no globals',
+        defaultValue: {},
+        typeChecker: function (object) { return true; },
+        typeError: '',
+    },
+    {
+        name: 'pages',
+        message: 'Assuming there are no pages',
+        defaultValue: {},
+        typeChecker: function (object) { return true; },
+        typeError: '',
+    },
+];
 var ConfigParser = (function () {
     function ConfigParser() {
     }
     ConfigParser.load = function (configPath) {
-        if (configPath === void 0) { configPath = path.join(process.cwd(), exports.DEFAULT_CONFIG_NAME); }
         Util_1.Util.debug('Loading Blitz config from `' + configPath + '`...');
         var configContent = Util_1.Util.getFileContents(configPath);
-        if (!configContent) {
-            Util_1.Util.error('Error loading config file! Are you sure `' + configPath + '` exists?');
-            return undefined;
-        }
         var config = Util_1.Util.parseYaml(configContent);
-        if (!config) {
-            Util_1.Util.error('Error parsing YAML! Are you sure `' + configPath + '` is valid?');
-            return undefined;
-        }
-        Util_1.Util.debug('Successfully parsed YAML!');
-        return config;
+        Util_1.Util.debug('Successfully parsed YAML in the config!');
+        return this.validate(config);
     };
-    ConfigParser.verify = function (config) {
-        return true;
+    ConfigParser.validate = function (config) {
+        Util_1.Util.debug('Validating Blitz config...');
+        var propertyCount = exports.CONFIG_PROPERTIES.length;
+        for (var i = 0; i < propertyCount; i++) {
+            var expected = exports.CONFIG_PROPERTIES[i];
+            var property = config[expected.name];
+            if (property === undefined) {
+                var displayValue = void 0;
+                if (typeof expected.defaultValue === 'string') {
+                    displayValue = '`' + expected.defaultValue + '`';
+                }
+                else {
+                    displayValue = JSON.stringify(expected.defaultValue);
+                }
+                var actionString = expected.message + ' (' + displayValue + ')';
+                Util_1.Util.warn('`' + expected.name.cyan + '` is not defined: ' + actionString);
+                config[expected.name] = expected.defaultValue;
+            }
+            else if (!expected.typeChecker(property)) {
+                var errorString = 'Invalid `' + expected.name + (_a = [""], _a.raw = [""], (' type: ')(_a)) + expected.typeError;
+                throw new Error(errorString);
+            }
+        }
+        Util_1.Util.debug('Successfully validated Blitz config!');
+        return config;
+        var _a;
     };
     return ConfigParser;
 }());

--- a/dist/src/ConfigParser.js
+++ b/dist/src/ConfigParser.js
@@ -48,8 +48,8 @@ exports.CONFIG_PROPERTIES = [
         name: 'pages',
         message: 'Assuming there are no pages',
         defaultValue: {},
-        typeChecker: function (object) { return typeof object === 'object' && !(object instanceof Array); },
-        typeError: 'Pages must be an object (and not an array)!',
+        typeChecker: function (object) { return typeof object === 'object' && object instanceof Array; },
+        typeError: 'Pages must be an array!',
     },
 ];
 var ConfigParser = (function () {

--- a/dist/src/ConfigParser.js
+++ b/dist/src/ConfigParser.js
@@ -47,7 +47,7 @@ exports.CONFIG_PROPERTIES = [
     {
         name: 'pages',
         message: 'Assuming there are no pages',
-        defaultValue: {},
+        defaultValue: [],
         typeChecker: function (object) { return typeof object === 'object' && object instanceof Array; },
         typeError: 'Pages must be an array!',
     },

--- a/dist/src/SiteBuilder.js
+++ b/dist/src/SiteBuilder.js
@@ -202,7 +202,14 @@ var SiteBuilder = (function () {
         if (parentUriComponents === void 0) { parentUriComponents = []; }
         var ownUriComponents;
         if (page.uri === undefined) {
-            ownUriComponents = [Util_1.Util.extractFileName(page.content)];
+            var fileNameSource = void 0;
+            if (page.content === undefined) {
+                fileNameSource = page.template;
+            }
+            else {
+                fileNameSource = page.content;
+            }
+            ownUriComponents = [Util_1.Util.extractFileName(fileNameSource)];
         }
         else {
             ownUriComponents = Util_1.Util.getUriComponents(page.uri);
@@ -218,7 +225,10 @@ var SiteBuilder = (function () {
         var currentPageDirectory = this.descendToDirectory(parentDirectory, partialDirectoryArray);
         var childrenDirectory = this.descendToDirectory(parentDirectory, ownUriComponents);
         var pageContent = page.content;
-        if (typeof page.content === 'string') {
+        if (pageContent === undefined) {
+            pageContent = {};
+        }
+        else if (typeof page.content === 'string') {
             pageContent = ContentParser_1.ContentParser.parseFile(path.join(this.contentPath, page.content));
         }
         var pugFunction = this.compilePug(path.join(this.templatesPath, page.template));
@@ -448,14 +458,7 @@ var SiteBuilder = (function () {
     };
     SiteBuilder.prototype.compilePug = function (path) {
         if (!this.pugCache[path]) {
-            try {
-                this.pugCache[path] = pug.compileFile(path);
-            }
-            catch (e) {
-                Util_1.Util.error('Error compiling `' + path + '`!');
-                Util_1.Util.stackTrace(e);
-                return undefined;
-            }
+            this.pugCache[path] = pug.compileFile(path);
         }
         return this.pugCache[path];
     };

--- a/dist/src/Util.js
+++ b/dist/src/Util.js
@@ -7,11 +7,20 @@ var colors = require('colors');
 var Util = (function () {
     function Util() {
     }
+    Util.getPackageInfo = function () {
+        if (this.packageInfoCache === undefined) {
+            this.packageInfoCache = require('../../package.json');
+        }
+        return this.packageInfoCache;
+    };
     Util.logWithPrefix = function (prefix, object) {
         console.log(prefix + ' ' + object.toString());
     };
     Util.log = function (object) {
         Util.logWithPrefix(colors.cyan('[Blitz LOG]'), object);
+    };
+    Util.warn = function (object) {
+        Util.logWithPrefix(colors.yellow('[Blitz WARN]'), object);
     };
     Util.error = function (object) {
         Util.logWithPrefix(colors.red('[Blitz ERROR]'), object);
@@ -30,16 +39,7 @@ var Util = (function () {
         if (yamlString === '') {
             return {};
         }
-        var parsedYaml;
-        try {
-            parsedYaml = yaml.safeLoad(yamlString);
-        }
-        catch (e) {
-            Util.error('Error parsing YAML!');
-            Util.stackTrace(e);
-            return undefined;
-        }
-        return parsedYaml;
+        return yaml.safeLoad(yamlString);
     };
     Util.parseMarkdown = function (markdown) {
         return marked(markdown);

--- a/dist/src/blitz.js
+++ b/dist/src/blitz.js
@@ -84,13 +84,7 @@ function init() {
 function build() {
     var directory = process.cwd();
     Util_1.Util.log('Building static site files in ' + directory + '...');
-    var config = ConfigParser_1.ConfigParser.load();
-    if (!config) {
-        return Util_1.Util.error('Could not load the config!');
-    }
-    if (!ConfigParser_1.ConfigParser.verify(config)) {
-        return Util_1.Util.error('ConfigParser is invalid!');
-    }
+    var config = ConfigParser_1.ConfigParser.load(path.join(process.cwd(), ConfigParser_1.DEFAULT_CONFIG_NAME));
     Util_1.Util.debug('Starting building process...');
     var builder = new SiteBuilder_1.SiteBuilder(config, directory, 'build');
     builder.build();

--- a/dist/test/ConfigParserTest.js
+++ b/dist/test/ConfigParserTest.js
@@ -40,10 +40,15 @@ describe('ConfigParser', function () {
                     hello: 'world',
                     integer: 123,
                 },
-                pages: {
-                    uri: '/',
-                    template: 'index.pug',
-                },
+                pages: [
+                    {
+                        uri: '/',
+                        template: 'index.pug',
+                    },
+                    {
+                        template: 'help.pug',
+                    },
+                ],
             };
             mock({
                 'blitz.yml': mock.file({

--- a/dist/test/ConfigParserTest.js
+++ b/dist/test/ConfigParserTest.js
@@ -1,0 +1,88 @@
+"use strict";
+var mock = require('mock-fs');
+var yaml = require('js-yaml');
+var chai_1 = require('chai');
+var ConfigParser_1 = require('../src/ConfigParser');
+describe('ConfigParser', function () {
+    describe('#load()', function () {
+        it('should throw an error when file either does not exist or is not readable', function () {
+            mock({
+                'blitz.yml': mock.file({
+                    content: '',
+                    mode: 0,
+                }),
+            });
+            chai_1.assert.throws(function () { return ConfigParser_1.ConfigParser.load('blitz.yml'); }, 'permission denied');
+            mock.restore();
+            mock({});
+            chai_1.assert.throws(function () { return ConfigParser_1.ConfigParser.load('blitz.yml'); }, 'no such file or directory');
+            mock.restore();
+        });
+        it('should use the default values correctly', function () {
+            mock({
+                'blitz.yml': mock.file({
+                    content: '',
+                    mode: 777,
+                }),
+            });
+            var config = ConfigParser_1.ConfigParser.load('blitz.yml');
+            mock.restore();
+            var propertyCount = ConfigParser_1.CONFIG_PROPERTIES.length;
+            for (var i = 0; i < propertyCount; i++) {
+                var property = ConfigParser_1.CONFIG_PROPERTIES[i];
+                chai_1.assert.deepEqual(config[property.name], property.defaultValue);
+            }
+        });
+        it('should read the config correctly', function () {
+            var configObject = {
+                blitz_version: '9.9.9',
+                globals: {
+                    hello: 'world',
+                    integer: 123,
+                },
+                pages: {
+                    uri: '/',
+                    template: 'index.pug',
+                },
+            };
+            mock({
+                'blitz.yml': mock.file({
+                    content: yaml.safeDump(configObject),
+                    mode: 777,
+                }),
+            });
+            var config = ConfigParser_1.ConfigParser.load('blitz.yml');
+            mock.restore();
+            for (var propertyName in configObject) {
+                if (configObject.hasOwnProperty(propertyName)) {
+                    chai_1.assert.deepEqual(config[propertyName], configObject[propertyName]);
+                }
+            }
+        });
+        it('should throw an error when an incorrect type for a required parameters is supplied', function () {
+            var propertyCount = ConfigParser_1.CONFIG_PROPERTIES.length;
+            for (var i = 0; i < propertyCount; i++) {
+                var property = ConfigParser_1.CONFIG_PROPERTIES[i];
+                var contentObject = {};
+                var badValue = void 0;
+                switch (typeof property.defaultValue) {
+                    case 'string':
+                    case 'boolean':
+                        badValue = {};
+                        break;
+                    default:
+                        badValue = 'string';
+                }
+                contentObject[property.name] = badValue;
+                mock({
+                    'blitz.yml': mock.file({
+                        content: yaml.safeDump(contentObject),
+                        mode: 777,
+                    }),
+                });
+                chai_1.assert.throws(function () { return ConfigParser_1.ConfigParser.load('blitz.yml'); }, 'Invalid type');
+                mock.restore();
+            }
+        });
+    });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blitz-ssg",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Dead simple static site generator using Markdown and Pug (formerly Jade).",
   "preferGlobal": true,
   "bin": {

--- a/src/ConfigParser.ts
+++ b/src/ConfigParser.ts
@@ -121,15 +121,15 @@ export const CONFIG_PROPERTIES: IConfigValidatorProperty[] = [
         name: 'globals',
         message: 'Assuming there are no globals',
         defaultValue: {},
-        typeChecker: (object) => true,
-        typeError: '',
+        typeChecker: (object) => typeof object === 'object' && !(object instanceof Array),
+        typeError: 'Globals must be an object (and not an array)!',
     },
     {
         name: 'pages',
         message: 'Assuming there are no pages',
         defaultValue: {},
-        typeChecker: (object) => true,
-        typeError: '',
+        typeChecker: (object) => typeof object === 'object' && !(object instanceof Array),
+        typeError: 'Pages must be an object (and not an array)!',
     },
 ];
 
@@ -172,7 +172,7 @@ export class ConfigParser {
                 Util.warn('`' + expected.name.cyan + '` is not defined: ' + actionString);
                 config[expected.name] = expected.defaultValue;
             } else if (!expected.typeChecker(property)) {
-                let errorString = 'Invalid `' + expected.name + ' type: '`` + expected.typeError;
+                let errorString = 'Invalid type for `' + expected.name + '`: ' + expected.typeError;
                 throw new Error(errorString);
             }
         }

--- a/src/ConfigParser.ts
+++ b/src/ConfigParser.ts
@@ -6,7 +6,6 @@
  * @since 0.0.1
  */
 
-import * as path from 'path';
 import {Util} from './Util';
 
 /**
@@ -67,37 +66,117 @@ export interface IBlitzConfig {
 }
 
 /**
+ * Interfaces for the config validation object
+ * @since 0.1.3
+ */
+export interface IConfigValidatorProperty {
+    name: string;
+    message: string;
+    defaultValue: any;
+    typeChecker: (object: any) => boolean;
+    typeError: string;
+}
+
+/**
+ * Array of default config properties.
+ * @since 0.1.3
+ */
+export const CONFIG_PROPERTIES: IConfigValidatorProperty[] = [
+    {
+        name: 'blitz_version',
+        message: 'Using current Blitz version',
+        defaultValue: Util.getPackageInfo().version,
+        typeChecker: (object) => typeof object === 'string',
+        typeError: 'Blitz version is supposed to be a string!',
+    },
+    {
+        name: 'site_url',
+        message: 'Using an empty string',
+        defaultValue: '',
+        typeChecker: (object) => typeof object === 'string',
+        typeError: 'Site URL is supposed to be a string!',
+    },
+    {
+        name: 'site_root',
+        message: 'Using an empty string',
+        defaultValue: '',
+        typeChecker: (object) => typeof object === 'string',
+        typeError: 'Site root is supposed to be a string!',
+    },
+    {
+        name: 'absolute_urls',
+        message: 'Disabling absolute URLs, using relative URLs instead',
+        defaultValue: false,
+        typeChecker: (object) => typeof object === 'boolean',
+        typeError: 'Absolute URLs should be a boolean value!',
+    },
+    {
+        name: 'explicit_html_extensions',
+        message: 'Enabling explicit HTML extensions',
+        defaultValue: true,
+        typeChecker: (object) => typeof object === 'boolean',
+        typeError: 'Explicit HTML extensions should be a boolean value!',
+    },
+    {
+        name: 'globals',
+        message: 'Assuming there are no globals',
+        defaultValue: {},
+        typeChecker: (object) => true,
+        typeError: '',
+    },
+    {
+        name: 'pages',
+        message: 'Assuming there are no pages',
+        defaultValue: {},
+        typeChecker: (object) => true,
+        typeError: '',
+    },
+];
+
+/**
  * @class Class responsible for various operations with the config
  * @since 0.0.1
  */
 export class ConfigParser {
     /**
-     * Loads YAML config from specified path
+     * Loads YAML config from specified path and verifies that it is a valid Bltiz config, creating required properties
+     * where possible.
      * @since 0.0.1
      */
-    public static load(configPath: string = path.join(process.cwd(), DEFAULT_CONFIG_NAME)): IBlitzConfig {
+    public static load(configPath: string): IBlitzConfig {
         Util.debug('Loading Blitz config from `' + configPath + '`...');
         let configContent = Util.getFileContents(configPath);
-        if (!configContent) {
-            Util.error('Error loading config file! Are you sure `' + configPath + '` exists?');
-            return undefined;
-        }
         let config = Util.parseYaml(configContent);
-        if (!config) {
-            Util.error('Error parsing YAML! Are you sure `' + configPath + '` is valid?');
-            return undefined;
-        }
-        Util.debug('Successfully parsed YAML!');
-
-        return config;
+        Util.debug('Successfully parsed YAML in the config!');
+        return this.validate(config);
     }
 
     /**
-     * Verifies that the supplied object is a valid Blitz config
-     * @since 0.0.1
+     * Validates Blitz config, creating required properties from default values where possible
+     * @since 0.1.3
      */
-    public static verify(config: any): boolean {
-        // TODO: Write actual checks
-        return true;
+    private static validate(config: any): IBlitzConfig {
+        Util.debug('Validating Blitz config...');
+        let propertyCount = CONFIG_PROPERTIES.length;
+        for (let i = 0; i < propertyCount; i++) {
+            let expected = CONFIG_PROPERTIES[i];
+            let property = config[expected.name];
+            if (property === undefined) {
+                let displayValue;
+                if (typeof expected.defaultValue === 'string') {
+                    displayValue = '`' + expected.defaultValue + '`';
+                } else {
+                    displayValue = JSON.stringify(expected.defaultValue);
+                }
+                let actionString = expected.message + ' (' + displayValue + ')';
+                Util.warn('`' + expected.name.cyan + '` is not defined: ' + actionString);
+                config[expected.name] = expected.defaultValue;
+            } else if (!expected.typeChecker(property)) {
+                let errorString = 'Invalid `' + expected.name + ' type: '`` + expected.typeError;
+                throw new Error(errorString);
+            }
+        }
+        Util.debug('Successfully validated Blitz config!');
+        return config;
     }
 }

--- a/src/ConfigParser.ts
+++ b/src/ConfigParser.ts
@@ -45,7 +45,7 @@ export interface IBlitzPage {
     id?: string;
     name?: string;
     template: string;
-    content: string|any;
+    content?: string|any;
     menus?: IBlitzMenu[];
     child_pages?: IBlitzPage[];
     child_directories?: IBlitzChildDirectory[];
@@ -128,8 +128,8 @@ export const CONFIG_PROPERTIES: IConfigValidatorProperty[] = [
         name: 'pages',
         message: 'Assuming there are no pages',
         defaultValue: {},
-        typeChecker: (object) => typeof object === 'object' && !(object instanceof Array),
-        typeError: 'Pages must be an object (and not an array)!',
+        typeChecker: (object) => typeof object === 'object' && object instanceof Array,
+        typeError: 'Pages must be an array!',
     },
 ];
 

--- a/src/ConfigParser.ts
+++ b/src/ConfigParser.ts
@@ -127,7 +127,7 @@ export const CONFIG_PROPERTIES: IConfigValidatorProperty[] = [
     {
         name: 'pages',
         message: 'Assuming there are no pages',
-        defaultValue: {},
+        defaultValue: [],
         typeChecker: (object) => typeof object === 'object' && object instanceof Array,
         typeError: 'Pages must be an array!',
     },

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -18,6 +18,23 @@ import * as colors from 'colors';
  */
 export class Util {
     /**
+     * Cache for package info
+     * @since 0.1.3
+     */
+    private static packageInfoCache: any;
+
+    /**
+     * Returns package info from `package.json`
+     * @since 0.1.3
+     */
+    public static getPackageInfo() {
+        if (this.packageInfoCache === undefined) {
+            this.packageInfoCache = require('../../package.json');
+        }
+        return this.packageInfoCache;
+    }
+
+    /**
      * Logs an object to console prefixing it with the specified string.
      * @since 0.0.1
      */
@@ -31,6 +48,14 @@ export class Util {
      */
     public static log(object: any) {
         Util.logWithPrefix(colors.cyan('[Blitz LOG]'), object);
+    }
+
+    /**
+     * Logs a warning into console
+     * @since 0.1.3
+     */
+    public static warn(object: any) {
+        Util.logWithPrefix(colors.yellow('[Blitz WARN]'), object);
     }
 
     /**
@@ -61,8 +86,8 @@ export class Util {
 
     /**
      * Produces an object from YAML string if possible, returns undefined otherwise.
-     * @deprecated
      * @since 0.1.2 Returns empty object for files that only have whitespace
+     * @since 0.1.2 Removed try/catch block
      * @since 0.0.1
      */
     public static parseYaml(yamlString: string): any {
@@ -71,15 +96,7 @@ export class Util {
         if (yamlString === '') {
             return {};
         }
-        let parsedYaml: any;
-        try {
-            parsedYaml = yaml.safeLoad(yamlString);
-        } catch (e) {
-            Util.error('Error parsing YAML!');
-            Util.stackTrace(e);
-            return undefined;
-        }
-        return parsedYaml;
+        return yaml.safeLoad(yamlString);
     }
 
     /**

--- a/src/blitz.ts
+++ b/src/blitz.ts
@@ -11,7 +11,7 @@ import * as fse from 'fs-extra';
 import * as path from 'path';
 import {SiteBuilder} from './SiteBuilder';
 import {Util} from './Util';
-import {ConfigParser} from './ConfigParser';
+import {ConfigParser, DEFAULT_CONFIG_NAME} from './ConfigParser';
 
 /**
  * Command line arguments passed to Blitz
@@ -114,13 +114,7 @@ function init() {
 function build() {
     let directory = process.cwd();
     Util.log('Building static site files in ' + directory + '...');
-    let config = ConfigParser.load();
-    if (!config) {
-        return Util.error('Could not load the config!');
-    }
-    if (!ConfigParser.verify(config)) {
-        return Util.error('ConfigParser is invalid!');
-    }
+    let config = ConfigParser.load(path.join(process.cwd(), DEFAULT_CONFIG_NAME));
     Util.debug('Starting building process...');
     let builder = new SiteBuilder(config, directory, 'build');
     builder.build();

--- a/templates/minimal/blitz.yml
+++ b/templates/minimal/blitz.yml
@@ -10,7 +10,7 @@
 
 # Version of Blitz used to generate this project. Used for
 # migration purposes.
-blitz_version: '0.1.2'
+blitz_version: '0.1.3'
 
 # Site URL without a trailing slash. This is not used in URL
 # generation but is rather available for your own convenience.

--- a/test/ConfigParserTest.ts
+++ b/test/ConfigParserTest.ts
@@ -52,10 +52,15 @@ describe('ConfigParser', () => {
                     hello: 'world',
                     integer: 123,
                 },
-                pages: {
-                    uri: '/',
-                    template: 'index.pug',
-                },
+                pages: [
+                    {
+                        uri: '/',
+                        template: 'index.pug',
+                    },
+                    {
+                        template: 'help.pug',
+                    },
+                ],
             };
             mock({
                 'blitz.yml': mock.file({

--- a/test/ConfigParserTest.ts
+++ b/test/ConfigParserTest.ts
@@ -1,0 +1,103 @@
+/**
+ * @file ConfigParser class tests
+ * @author Timur Kuzhagaliyev <tim.kuzh@gmail.com>
+ * @copyright 2016
+ * @license GPL-3.0
+ * @since 0.1.3
+ */
+
+import * as mock from 'mock-fs';
+import * as yaml from 'js-yaml';
+import {assert} from 'chai';
+import {ConfigParser, CONFIG_PROPERTIES} from '../src/ConfigParser';
+
+describe('ConfigParser', () => {
+
+    describe('#load()', () => {
+
+        it('should throw an error when file either does not exist or is not readable', () => {
+            mock({
+                'blitz.yml': mock.file({
+                    content: '',
+                    mode: 0,
+                }),
+            });
+            assert.throws(() => ConfigParser.load('blitz.yml'), 'permission denied');
+            mock.restore();
+            mock({});
+            assert.throws(() => ConfigParser.load('blitz.yml'), 'no such file or directory');
+            mock.restore();
+        });
+
+        it('should use the default values correctly', () => {
+            mock({
+                'blitz.yml': mock.file({
+                    content: '',
+                    mode: 777,
+                }),
+            });
+            let config = ConfigParser.load('blitz.yml');
+            mock.restore();
+            let propertyCount = CONFIG_PROPERTIES.length;
+            for (let i = 0; i < propertyCount; i++) {
+                let property = CONFIG_PROPERTIES[i];
+                assert.deepEqual(config[property.name], property.defaultValue);
+            }
+        });
+
+        it('should read the config correctly', () => {
+            let configObject = {
+                blitz_version: '9.9.9',
+                globals: {
+                    hello: 'world',
+                    integer: 123,
+                },
+                pages: {
+                    uri: '/',
+                    template: 'index.pug',
+                },
+            };
+            mock({
+                'blitz.yml': mock.file({
+                    content: yaml.safeDump(configObject),
+                    mode: 777,
+                }),
+            });
+            let config = ConfigParser.load('blitz.yml');
+            mock.restore();
+            for (let propertyName in configObject) {
+                if (configObject.hasOwnProperty(propertyName)) {
+                    assert.deepEqual(config[propertyName], configObject[propertyName]);
+                }
+            }
+        });
+
+        it('should throw an error when an incorrect type for a required parameters is supplied', () => {
+            let propertyCount = CONFIG_PROPERTIES.length;
+            for (let i = 0; i < propertyCount; i++) {
+                let property = CONFIG_PROPERTIES[i];
+                let contentObject = {};
+                let badValue;
+                switch (typeof property.defaultValue) {
+                    case 'string':
+                    case 'boolean':
+                        badValue = {};
+                        break;
+                    default:
+                        badValue = 'string';
+                }
+                contentObject[property.name] = badValue;
+                mock({
+                    'blitz.yml': mock.file({
+                        content: yaml.safeDump(contentObject),
+                        mode: 777,
+                    }),
+                });
+                assert.throws(() => ConfigParser.load('blitz.yml'), 'Invalid type');
+                mock.restore();
+            }
+        });
+
+    });
+
+});

--- a/test/ContentParserTest.ts
+++ b/test/ContentParserTest.ts
@@ -1,5 +1,5 @@
 /**
- * @file ConfigParser class tests
+ * @file ContentParser class tests
  * @author Timur Kuzhagaliyev <tim.kuzh@gmail.com>
  * @copyright 2016
  * @license GPL-3.0


### PR DESCRIPTION
* Added config property validation. Blitz will now check the config for required properties and add them using default values if said properties are missing, or throw an error if the type of the property is invalid.
* Made `content` for pages optional. If `content` is empty, Blitz is just going to render the file specified in `template` as if the `content` pointed to an empty file. Keep in mind, since `uri` is also optional you can now create pages using only 1 line, like so:
    ```yaml
    # In the config:
    pages:
      - template: 'index.pug'
      - template: 'help.pug'
    ```